### PR TITLE
Update to install more modern node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir uv
 
 # install npx to run stdio clients (npx)
-RUN apt-get update && apt-get install -y --no-install-recommends npm
+RUN apt-get update && apt-get install -y --no-install-recommends curl
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt-get install -y --no-install-recommends nodejs
 
 COPY mcp_bridge mcp_bridge
 


### PR DESCRIPTION
Currently it looks like the base image node is utilizing some variant of 7.x for npx which is causing issues with several of the node based mcp server examples from anthropic. Updating to node 20.x seems to resolve all of the errors and puts us in an lts install for node. 

Prior to this fix both  of these example servers do not work. After the fix they do : 

https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search
https://github.com/modelcontextprotocol/servers/tree/main/src/memory