### PR TITLE
Potential fix for code scanning alert no. 3: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.7
       with:
         name: python-package-distributions
         path: .


### PR DESCRIPTION
Potential fix for [https://github.com/SecretiveShell/MCP-Bridge/security/code-scanning/3](https://github.com/SecretiveShell/MCP-Bridge/security/code-scanning/3)

To fix the problem, we need to update the `actions/download-artifact` action from version `v3` to `4.1.7`, which is not vulnerable. This change should be made in the `.github/workflows/release.yaml` file. The update will ensure that the workflow uses a secure version of the action without changing its existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
