### PR TITLE
README.md: Fix auth config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ MCP-Bridge supports API key authentication to secure your server. To enable this
       "auth": {
         "enabled": true,
         "api_keys": [
-          {"key": "your-secure-api-key-here"}
+          {
+            "key": "your-secure-api-key-here"
+          }
         ]
       }
     }
@@ -187,7 +189,9 @@ an example config.json file with most of the options explicitly set:
       "auth": {
         "enabled": true,
         "api_keys": [
-          {"key": "your-secure-api-key-here"}
+          {
+            "key": "your-secure-api-key-here"
+          }
         ]
       }
     },

--- a/README.md
+++ b/README.md
@@ -125,11 +125,18 @@ To add new MCP servers, edit the config.json file.
 
 ### API Key Authentication
 
-MCP-Bridge supports API key authentication to secure your server. To enable this feature, add an `api_key` field to your config.json file:
+MCP-Bridge supports API key authentication to secure your server. To enable this feature, add something like this to your `config.json` file:
 
 ```json
 {
-    "api_key": "your-secure-api-key-here"
+    "security": {
+      "auth": {
+        "enabled": true,
+        "api_keys": [
+          {"key": "your-secure-api-key-here"}
+        ]
+      }
+    }
 }
 ```
 
@@ -176,14 +183,21 @@ an example config.json file with most of the options explicitly set:
             ]
         }
     },
+    "security": {
+      "auth": {
+        "enabled": true,
+        "api_keys": [
+          {"key": "your-secure-api-key-here"}
+        ]
+      }
+    },
     "network": {
         "host": "0.0.0.0",
         "port": 9090
     },
     "logging": {
         "log_level": "DEBUG"
-    },
-    "api_key": "your-secure-api-key-here"
+    }
 }
 ```
 


### PR DESCRIPTION
The auth config examples in the `README.md` don't work. I updated them with configs that do work.

Preview at https://github.com/msabramo/MCP-Bridge/blob/patch-1/README.md#api-key-authentication