### PR TITLE
Remove blocking behavior workaround in MCP ClientSession

### DIFF
--- a/mcp_bridge/mcp_clients/session.py
+++ b/mcp_bridge/mcp_clients/session.py
@@ -40,31 +40,6 @@ class McpClientSession(
             read_timeout_seconds=read_timeout_seconds,
         )
 
-    async def __aenter__(self):
-        session = await super().__aenter__()
-        self._task_group.start_soon(self._consume_messages)
-        return session
-
-    async def _consume_messages(self):
-        try:
-            async for message in self.incoming_messages:
-                try:
-                    if isinstance(message, Exception):
-                        logger.error(f"Received exception in message stream: {message}")
-                    elif isinstance(message, RequestResponder):                        
-                        logger.debug(f"Received request: {message.request}")                        
-                    elif isinstance(message, types.ServerNotification):
-                        if isinstance(message.root, types.LoggingMessageNotification):
-                            logger.debug(f"Received notification from server: {message.root.params}")                        
-                        else:
-                            logger.debug(f"Received notification from server: {message}")                        
-                    else:
-                        logger.debug(f"Received notification: {message}")
-                except Exception as e:
-                    logger.exception(f"Error processing message: {e}")
-        except Exception as e:
-            logger.exception(f"Message consumer task failed: {e}")
-
     async def initialize(self) -> types.InitializeResult:
         result = await self.send_request(
             types.ClientRequest(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "httpx-sse>=0.4.0",
     "lmos-openai-types",
     "loguru>=0.7.3",
-    "mcp>=1.2.0,<=1.7.1",
+    "mcp>=1.6.0,<=1.7.1",
     "mcpx[docker]>=0.1.1",
     "opentelemetry-api>=1.33.1",
     "opentelemetry-exporter-otlp>=1.33.1",

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ requires-dist = [
     { name = "httpx-sse", specifier = ">=0.4.0" },
     { name = "lmos-openai-types", git = "https://github.com/LMOS-IO/LMOS-openai-types?rev=pydantic-gen" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "mcp", specifier = ">=1.2.0,<=1.7.1" },
+    { name = "mcp", specifier = ">=1.6.0,<=1.7.1" },
     { name = "mcpx", extras = ["docker"], specifier = ">=0.1.1" },
     { name = "opentelemetry-api", specifier = ">=1.33.1" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.33.1" },


### PR DESCRIPTION
This reverts commit d3c2c0f869d694e9d01d19a85e634bfb91205c95. This workaround is not necessary anymore and now harmful since the fix is applied in MCP 1.6.0.

https://github.com/modelcontextprotocol/python-sdk/pull/325

Fixes #76 